### PR TITLE
Convert for..of object loop to for..in range loop in client.coffee

### DIFF
--- a/client.coffee
+++ b/client.coffee
@@ -22,7 +22,10 @@ LocalCollection._compileProjection = (fields) ->
   (obj) ->
     res = fun obj
 
-    for field of res when field.lastIndexOf('_sub_', 0) is 0
-      delete res[field]
+    fields = Object.keys(res);
+
+    for i in [0...fields.length]
+      if fields[i].lastIndexOf('_sub_', 0) is 0
+        delete res[fields[i]]
 
     res


### PR DESCRIPTION
Since this PR to Meteor 1.8.2 https://github.com/meteor/meteor/pull/10596, the client gives an error in client.coffee "ReferenceError: meteorBabelHelpers is not defined". There is more relevant discussion here for a similar issue: https://github.com/meteor/meteor/issues/7184

This PR fixes the problem, but perhaps there is a more correct solution. 